### PR TITLE
Update CTT.cfg

### DIFF
--- a/GameData/UmbraSpaceIndustries/WarpDrive/CTT.cfg
+++ b/GameData/UmbraSpaceIndustries/WarpDrive/CTT.cfg
@@ -1,9 +1,9 @@
-@PART[USI_WarpDrive]:NEEDS[CommunityTechTree,TechManager]
+@PART[USI_WarpDrive]:NEEDS[CommunityTechTree]
 {
 	@TechRequired = ultraHighEnergyPhysics
 }
 
-@PART[USI_WarpDrive_625]:NEEDS[CommunityTechTree,TechManager]
+@PART[USI_WarpDrive_625]:NEEDS[CommunityTechTree]
 {
 	@TechRequired = ultraHighEnergyPhysics
 }


### PR DESCRIPTION
Techmanager is no longer used for CTT, so is no longer needed for the MM patch.
