### PR TITLE
Updated warp bubble guide

### DIFF
--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/WarpDrive/Parts/ZWarpDrive375.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/WarpDrive/Parts/ZWarpDrive375.cfg
@@ -13,7 +13,7 @@ MODEL
 MODEL // This does the warp bubble effect and VAB SPH guide
 {
 	model = UmbraSpaceIndustries/WarpDrive/Assets/WarpBubble
-	scale = 2.2,2.2,2.2
+	scale = 1.875,1.875,1.875
 }
 node_stack_top = 0.0, 0.90, 0.0, 0.0, 3.0, 0.0, 3
 node_stack_bottom = 0.0, -0.711, 0.0, 0.0, -3.0, 0.0, 3


### PR DESCRIPTION
Warp bubble guide set to 1.875 to match the bubble size of 37.5. 880470a93ca8155c7cbf0fe25295d625f0ae0014 reduced bubble size from 44 to 37.5 but didn't reduce the guide.
Should close issue #60 unless you instead wanted the bubble size increased to 