### PR TITLE
Make bubble size a double to support value of 37.5 in ZWarpDrive375

### DIFF
--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/WarpDrive/Parts/WarpDrive_250.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/WarpDrive/Parts/WarpDrive_250.cfg
@@ -53,13 +53,6 @@ bulkheadProfiles = size2
 fx_exhaustFlame_blue_small = 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, running
 fx_exhaustLight_blue = 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, running
 
- --- Sound FX definition ---
-sound_vent_medium = engage
-sound_jet_low = running
-sound_jet_deep = power
-sound_vent_soft = disengage
-sound_explosion_low = flameout
-
 MODULE
 {
 	name = USI_ModuleWarpEngine
@@ -105,7 +98,7 @@ MODULE
 
 MODULE
 {
-	name = ModuleEngines
+	name = ModuleEnginesFX
 	thrustVectorTransformName = thrustTransform
 	exhaustDamage = False
 	ignitionThreshold = 0.01
@@ -113,6 +106,16 @@ MODULE
 	maxThrust = .00075
 	heatProduction = 100
 	fxOffset = 0, 0, 0
+
+	// --- Sound FX definition ---
+	flameoutEffectName = flameout
+	powerEffectName = power
+	runningEffectName = running
+	engageEffectName = engage
+	disengageEffectName = disengage
+	spoolEffectName =
+	directThrottleEffectName =
+
 	PROPELLANT
 	{
 		name = ElectricCharge
@@ -153,6 +156,72 @@ RESOURCE
  maxAmount = 1800
 }
 
+	EFFECTS
+	{
+		power
+		{
+			AUDIO
+			{
+				channel = Ship
+				clip = sound_jet_deep
+				volume = 0.0 0.0
+				volume = 0.5 0.8
+				volume = 1.0 1.0
+				pitch = 0.0 0.5
+				pitch = 1.0 1.0
+				loop = true
+			}
+		}
+		running
+		{
+			AUDIO
+			{
+				channel = Ship
+				clip = sound_jet_low
+				volume = 0.0 0.0
+				volume = 0.1 0.3
+				volume = 0.5 0.4
+				volume = 1.0 0.5
+				pitch = 0.0 0.2
+				pitch = 0.5 0.8
+				pitch = 1.0 1.0
+				loop = true
+			}
+		}
+		engage
+		{
+			AUDIO
+			{
+				channel = Ship
+				clip = sound_vent_medium
+				volume = 1.0
+				pitch = 2.0
+				loop = false
+			}
+		}
+		disengage
+		{
+			AUDIO
+			{
+				channel = Ship
+				clip = sound_vent_soft
+				volume = 1.0
+				pitch = 2.0
+				loop = false
+			}
+		}
+		flameout
+		{
+			AUDIO
+			{
+				channel = Ship
+				clip = sound_explosion_low
+				volume = 1.0
+				pitch = 2.0
+				loop = false
+			}
+		}
+	}
 }
 
 

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/WarpDrive/Parts/WarpDrive_625.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/WarpDrive/Parts/WarpDrive_625.cfg
@@ -52,13 +52,6 @@ bulkheadProfiles = size0
 
 fx_exhaustLight_blue = 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, running
 
- --- Sound FX definition ---
-sound_vent_medium = engage
-sound_jet_low = running
-sound_jet_deep = power
-sound_vent_soft = disengage
-sound_explosion_low = flameout
-
 MODULE
 {
 	name = USI_ModuleWarpEngine
@@ -104,7 +97,7 @@ MODULE
 
 MODULE
 {
-	name = ModuleEngines
+	name = ModuleEnginesFX
 	thrustVectorTransformName = thrustTransform
 	exhaustDamage = False
 	ignitionThreshold = 0.01
@@ -112,6 +105,16 @@ MODULE
 	maxThrust = .00018
 	heatProduction = 100
 	fxOffset = 0, 0, 0
+
+	// --- Sound FX definition ---
+	flameoutEffectName = flameout
+	powerEffectName = power
+	runningEffectName = running
+	engageEffectName = engage
+	disengageEffectName = disengage
+	spoolEffectName =
+	directThrottleEffectName =
+
 	PROPELLANT
 	{
 		name = ElectricCharge
@@ -152,6 +155,72 @@ RESOURCE
  maxAmount = 450
 }
 
+	EFFECTS
+	{
+		power
+		{
+			AUDIO
+			{
+				channel = Ship
+				clip = sound_jet_deep
+				volume = 0.0 0.0
+				volume = 0.5 0.8
+				volume = 1.0 1.0
+				pitch = 0.0 0.5
+				pitch = 1.0 1.0
+				loop = true
+			}
+		}
+		running
+		{
+			AUDIO
+			{
+				channel = Ship
+				clip = sound_jet_low
+				volume = 0.0 0.0
+				volume = 0.1 0.3
+				volume = 0.5 0.4
+				volume = 1.0 0.5
+				pitch = 0.0 0.2
+				pitch = 0.5 0.8
+				pitch = 1.0 1.0
+				loop = true
+			}
+		}
+		engage
+		{
+			AUDIO
+			{
+				channel = Ship
+				clip = sound_vent_medium
+				volume = 1.0
+				pitch = 2.0
+				loop = false
+			}
+		}
+		disengage
+		{
+			AUDIO
+			{
+				channel = Ship
+				clip = sound_vent_soft
+				volume = 1.0
+				pitch = 2.0
+				loop = false
+			}
+		}
+		flameout
+		{
+			AUDIO
+			{
+				channel = Ship
+				clip = sound_explosion_low
+				volume = 1.0
+				pitch = 2.0
+				loop = false
+			}
+		}
+	}
 }
 
 

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/WarpDrive/Parts/ZWarpDrive125.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/WarpDrive/Parts/ZWarpDrive125.cfg
@@ -44,13 +44,6 @@ angularDrag = 2
 crashTolerance = 25
 maxTemp = 2900
 
-
- --- Sound FX definition ---
-sound_vent_medium = engage
-sound_jet_low = running
-sound_jet_deep = power
-sound_vent_soft = disengage
-sound_explosion_low = flameout
 MODULE
 {
 	name = USI_ModuleWarpEngine
@@ -95,7 +88,7 @@ MODULE
 }
 MODULE
 {
-	name = ModuleEngines
+	name = ModuleEnginesFX
 	thrustVectorTransformName = thrustTransform
 	exhaustDamage = False
 	ignitionThreshold = 0.01
@@ -103,6 +96,16 @@ MODULE
 	maxThrust = .0003
 	heatProduction = 100
 	fxOffset = 0, 0, 0
+
+	// --- Sound FX definition ---
+	flameoutEffectName = flameout
+	powerEffectName = power
+	runningEffectName = running
+	engageEffectName = engage
+	disengageEffectName = disengage
+	spoolEffectName =
+	directThrottleEffectName =
+
 	PROPELLANT
 	{
 		name = ElectricCharge
@@ -143,4 +146,70 @@ RESOURCE
  maxAmount = 600
 }
 
+	EFFECTS
+	{
+		power
+		{
+			AUDIO
+			{
+				channel = Ship
+				clip = sound_jet_deep
+				volume = 0.0 0.0
+				volume = 0.5 0.8
+				volume = 1.0 1.0
+				pitch = 0.0 0.5
+				pitch = 1.0 1.0
+				loop = true
+			}
+		}
+		running
+		{
+			AUDIO
+			{
+				channel = Ship
+				clip = sound_jet_low
+				volume = 0.0 0.0
+				volume = 0.1 0.3
+				volume = 0.5 0.4
+				volume = 1.0 0.5
+				pitch = 0.0 0.2
+				pitch = 0.5 0.8
+				pitch = 1.0 1.0
+				loop = true
+			}
+		}
+		engage
+		{
+			AUDIO
+			{
+				channel = Ship
+				clip = sound_vent_medium
+				volume = 1.0
+				pitch = 2.0
+				loop = false
+			}
+		}
+		disengage
+		{
+			AUDIO
+			{
+				channel = Ship
+				clip = sound_vent_soft
+				volume = 1.0
+				pitch = 2.0
+				loop = false
+			}
+		}
+		flameout
+		{
+			AUDIO
+			{
+				channel = Ship
+				clip = sound_explosion_low
+				volume = 1.0
+				pitch = 2.0
+				loop = false
+			}
+		}
+	}
 }

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/WarpDrive/Parts/ZWarpDrive25.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/WarpDrive/Parts/ZWarpDrive25.cfg
@@ -44,13 +44,6 @@ angularDrag = 2
 crashTolerance = 25
 maxTemp = 2900
 
-
- --- Sound FX definition ---
-sound_vent_medium = engage
-sound_jet_low = running
-sound_jet_deep = power
-sound_vent_soft = disengage
-sound_explosion_low = flameout
 MODULE
 {
 	name = USI_ModuleWarpEngine
@@ -96,7 +89,7 @@ MODULE
 
 MODULE
 {
-	name = ModuleEngines
+	name = ModuleEnginesFX
 	thrustVectorTransformName = thrustTransform
 	exhaustDamage = False
 	ignitionThreshold = 0.01
@@ -104,6 +97,16 @@ MODULE
 	maxThrust = .00075
 	heatProduction = 100
 	fxOffset = 0, 0, 0
+
+	// --- Sound FX definition ---
+	flameoutEffectName = flameout
+	powerEffectName = power
+	runningEffectName = running
+	engageEffectName = engage
+	disengageEffectName = disengage
+	spoolEffectName =
+	directThrottleEffectName =
+
 	PROPELLANT
 	{
 		name = ElectricCharge
@@ -144,4 +147,70 @@ RESOURCE
  maxAmount = 1500
 }
 
+	EFFECTS
+	{
+		power
+		{
+			AUDIO
+			{
+				channel = Ship
+				clip = sound_jet_deep
+				volume = 0.0 0.0
+				volume = 0.5 0.8
+				volume = 1.0 1.0
+				pitch = 0.0 0.5
+				pitch = 1.0 1.0
+				loop = true
+			}
+		}
+		running
+		{
+			AUDIO
+			{
+				channel = Ship
+				clip = sound_jet_low
+				volume = 0.0 0.0
+				volume = 0.1 0.3
+				volume = 0.5 0.4
+				volume = 1.0 0.5
+				pitch = 0.0 0.2
+				pitch = 0.5 0.8
+				pitch = 1.0 1.0
+				loop = true
+			}
+		}
+		engage
+		{
+			AUDIO
+			{
+				channel = Ship
+				clip = sound_vent_medium
+				volume = 1.0
+				pitch = 2.0
+				loop = false
+			}
+		}
+		disengage
+		{
+			AUDIO
+			{
+				channel = Ship
+				clip = sound_vent_soft
+				volume = 1.0
+				pitch = 2.0
+				loop = false
+			}
+		}
+		flameout
+		{
+			AUDIO
+			{
+				channel = Ship
+				clip = sound_explosion_low
+				volume = 1.0
+				pitch = 2.0
+				loop = false
+			}
+		}
+	}
 }

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/WarpDrive/Parts/ZWarpDrive375.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/WarpDrive/Parts/ZWarpDrive375.cfg
@@ -38,14 +38,6 @@ breakingForce = 12690
 breakingTorque = 12690
 maxTemp = 2900
 
-
- --- Sound FX definition ---
-sound_vent_medium = engage
-sound_jet_low = running
-sound_jet_deep = power
-sound_vent_soft = disengage
-sound_explosion_low = flameout
-
 MODULE
 {
 	name = USI_ModuleWarpEngine
@@ -91,7 +83,7 @@ MODULE
 
 MODULE
 {
-	name = ModuleEngines
+	name = ModuleEnginesFX
 	thrustVectorTransformName = thrustTransform
 	exhaustDamage = False
 	ignitionThreshold = 0.01
@@ -99,6 +91,16 @@ MODULE
 	maxThrust = .001
 	heatProduction = 100
 	fxOffset = 0, 0, 0
+
+	// --- Sound FX definition ---
+	flameoutEffectName = flameout
+	powerEffectName = power
+	runningEffectName = running
+	engageEffectName = engage
+	disengageEffectName = disengage
+	spoolEffectName =
+	directThrottleEffectName =
+
 	PROPELLANT
 	{
 		name = ElectricCharge
@@ -139,4 +141,70 @@ RESOURCE
  maxAmount = 2000
 }
 
+	EFFECTS
+	{
+		power
+		{
+			AUDIO
+			{
+				channel = Ship
+				clip = sound_jet_deep
+				volume = 0.0 0.0
+				volume = 0.5 0.8
+				volume = 1.0 1.0
+				pitch = 0.0 0.5
+				pitch = 1.0 1.0
+				loop = true
+			}
+		}
+		running
+		{
+			AUDIO
+			{
+				channel = Ship
+				clip = sound_jet_low
+				volume = 0.0 0.0
+				volume = 0.1 0.3
+				volume = 0.5 0.4
+				volume = 1.0 0.5
+				pitch = 0.0 0.2
+				pitch = 0.5 0.8
+				pitch = 1.0 1.0
+				loop = true
+			}
+		}
+		engage
+		{
+			AUDIO
+			{
+				channel = Ship
+				clip = sound_vent_medium
+				volume = 1.0
+				pitch = 2.0
+				loop = false
+			}
+		}
+		disengage
+		{
+			AUDIO
+			{
+				channel = Ship
+				clip = sound_vent_soft
+				volume = 1.0
+				pitch = 2.0
+				loop = false
+			}
+		}
+		flameout
+		{
+			AUDIO
+			{
+				channel = Ship
+				clip = sound_explosion_low
+				volume = 1.0
+				pitch = 2.0
+				loop = false
+			}
+		}
+	}
 }

--- a/Source/WarpEngine/WarpEngine/USI_ModuleWarpEngine.cs
+++ b/Source/WarpEngine/WarpEngine/USI_ModuleWarpEngine.cs
@@ -39,7 +39,7 @@ namespace WarpEngine
         public int DisruptRange = 2000;
 
         [KSPField]
-        public int BubbleSize = 20;
+        public double BubbleSize = 20d;
 
         [KSPField]
         public double MinAltitude = 1d;


### PR DESCRIPTION
ZWarpDrive375 wants to set a bubble size of 37.5 but because the variable was an integer, this setting was ignored and so the bubble size remained at the default value of 20. This fixes the problem by making the variable a double.